### PR TITLE
Add privacy policy page and footer link

### DIFF
--- a/about.html
+++ b/about.html
@@ -218,6 +218,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2020/aaron_paul.html
+++ b/articles/fall-2020/aaron_paul.html
@@ -170,6 +170,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2020/artificial_intelligence.html
+++ b/articles/fall-2020/artificial_intelligence.html
@@ -169,6 +169,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2020/business_model.html
+++ b/articles/fall-2020/business_model.html
@@ -210,6 +210,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2020/gig_economy.html
+++ b/articles/fall-2020/gig_economy.html
@@ -189,6 +189,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2020/lumaki_labs.html
+++ b/articles/fall-2020/lumaki_labs.html
@@ -183,6 +183,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2020/nitish_sharma.html
+++ b/articles/fall-2020/nitish_sharma.html
@@ -174,6 +174,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2020/tik_tok.html
+++ b/articles/fall-2020/tik_tok.html
@@ -192,6 +192,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2021/lab_grown_meat.html
+++ b/articles/fall-2021/lab_grown_meat.html
@@ -228,6 +228,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2021/machine_learning.html
+++ b/articles/fall-2021/machine_learning.html
@@ -225,6 +225,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2021/private_equity.html
+++ b/articles/fall-2021/private_equity.html
@@ -234,6 +234,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2021/roblox.html
+++ b/articles/fall-2021/roblox.html
@@ -211,6 +211,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2022/crisis.html
+++ b/articles/fall-2022/crisis.html
@@ -387,6 +387,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2022/dd.html
+++ b/articles/fall-2022/dd.html
@@ -407,6 +407,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2022/dr.html
+++ b/articles/fall-2022/dr.html
@@ -305,6 +305,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2022/meta.html
+++ b/articles/fall-2022/meta.html
@@ -454,6 +454,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2022/tesla.html
+++ b/articles/fall-2022/tesla.html
@@ -381,6 +381,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2023/cashless.html
+++ b/articles/fall-2023/cashless.html
@@ -247,6 +247,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2023/foreign.html
+++ b/articles/fall-2023/foreign.html
@@ -248,6 +248,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2023/japan.html
+++ b/articles/fall-2023/japan.html
@@ -233,6 +233,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2023/novo-nordisk.html
+++ b/articles/fall-2023/novo-nordisk.html
@@ -259,6 +259,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2023/pegasus.html
+++ b/articles/fall-2023/pegasus.html
@@ -305,6 +305,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2023/space.html
+++ b/articles/fall-2023/space.html
@@ -208,6 +208,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2023/tech-gap.html
+++ b/articles/fall-2023/tech-gap.html
@@ -261,6 +261,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2025/ai_and_nuclear.html
+++ b/articles/fall-2025/ai_and_nuclear.html
@@ -220,6 +220,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2025/decline_of_luxury.html
+++ b/articles/fall-2025/decline_of_luxury.html
@@ -198,6 +198,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2025/neurotech_in_the_future.html
+++ b/articles/fall-2025/neurotech_in_the_future.html
@@ -196,6 +196,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/fall-2025/rejected_by_your_bank.html
+++ b/articles/fall-2025/rejected_by_your_bank.html
@@ -254,6 +254,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2020/alternative_credit_analytics.html
+++ b/articles/spring-2020/alternative_credit_analytics.html
@@ -174,6 +174,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2020/bitcoin.html
+++ b/articles/spring-2020/bitcoin.html
@@ -197,6 +197,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2020/esports.html
+++ b/articles/spring-2020/esports.html
@@ -214,6 +214,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2020/ismail_mian.html
+++ b/articles/spring-2020/ismail_mian.html
@@ -173,6 +173,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2020/kuba_soltysiak.html
+++ b/articles/spring-2020/kuba_soltysiak.html
@@ -195,6 +195,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2020/talha_siddiqui.html
+++ b/articles/spring-2020/talha_siddiqui.html
@@ -170,6 +170,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2020/tesla.html
+++ b/articles/spring-2020/tesla.html
@@ -208,6 +208,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2020/the_streaming_wars.html
+++ b/articles/spring-2020/the_streaming_wars.html
@@ -191,6 +191,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2021/bigtech.html
+++ b/articles/spring-2021/bigtech.html
@@ -211,6 +211,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2021/esg.html
+++ b/articles/spring-2021/esg.html
@@ -204,6 +204,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2021/hacking.html
+++ b/articles/spring-2021/hacking.html
@@ -210,6 +210,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2021/india.html
+++ b/articles/spring-2021/india.html
@@ -201,6 +201,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2021/mike_hejmej.html
+++ b/articles/spring-2021/mike_hejmej.html
@@ -184,6 +184,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2021/nft.html
+++ b/articles/spring-2021/nft.html
@@ -215,6 +215,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2021/stephanie_han.html
+++ b/articles/spring-2021/stephanie_han.html
@@ -184,6 +184,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2021/walmart.html
+++ b/articles/spring-2021/walmart.html
@@ -197,6 +197,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2024/ai-journalism.html
+++ b/articles/spring-2024/ai-journalism.html
@@ -190,6 +190,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2024/celebrity-vc-pipeline.html
+++ b/articles/spring-2024/celebrity-vc-pipeline.html
@@ -379,6 +379,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2024/digital-economy.html
+++ b/articles/spring-2024/digital-economy.html
@@ -323,6 +323,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2024/esports-future.html
+++ b/articles/spring-2024/esports-future.html
@@ -326,6 +326,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2024/mcdonalds-fall.html
+++ b/articles/spring-2024/mcdonalds-fall.html
@@ -302,6 +302,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2025/a_and_r_playbook.html
+++ b/articles/spring-2025/a_and_r_playbook.html
@@ -220,6 +220,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2025/boringjobs.html
+++ b/articles/spring-2025/boringjobs.html
@@ -165,6 +165,7 @@ Overlooked Value in Boring Businesses</a></li>
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2025/cover_retail.html
+++ b/articles/spring-2025/cover_retail.html
@@ -224,6 +224,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2025/fire.html
+++ b/articles/spring-2025/fire.html
@@ -181,6 +181,7 @@ How Firefighting Became the Nation’s Most Effective Public Service </a></li>
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/spring-2025/ipl.html
+++ b/articles/spring-2025/ipl.html
@@ -187,6 +187,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2021/SPAC.html
+++ b/articles/winter-2021/SPAC.html
@@ -186,6 +186,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2021/african_renaissance.html
+++ b/articles/winter-2021/african_renaissance.html
@@ -198,6 +198,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2021/blackberry.html
+++ b/articles/winter-2021/blackberry.html
@@ -193,6 +193,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2021/business_value.html
+++ b/articles/winter-2021/business_value.html
@@ -202,6 +202,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2021/psychedelics.html
+++ b/articles/winter-2021/psychedelics.html
@@ -212,6 +212,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2021/starter_hacks.html
+++ b/articles/winter-2021/starter_hacks.html
@@ -184,6 +184,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2024/bnpl.html
+++ b/articles/winter-2024/bnpl.html
@@ -434,6 +434,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2024/budget-airlines.html
+++ b/articles/winter-2024/budget-airlines.html
@@ -377,6 +377,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2024/digital-banking.html
+++ b/articles/winter-2024/digital-banking.html
@@ -362,6 +362,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2024/european-energy.html
+++ b/articles/winter-2024/european-energy.html
@@ -367,6 +367,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2024/f1.html
+++ b/articles/winter-2024/f1.html
@@ -386,6 +386,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2024/us-dependency.html
+++ b/articles/winter-2024/us-dependency.html
@@ -354,6 +354,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2025/apac.html
+++ b/articles/winter-2025/apac.html
@@ -207,6 +207,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2025/disney.html
+++ b/articles/winter-2025/disney.html
@@ -195,6 +195,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2025/openai.html
+++ b/articles/winter-2025/openai.html
@@ -214,6 +214,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2025/sports.html
+++ b/articles/winter-2025/sports.html
@@ -204,6 +204,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/articles/winter-2025/vr.html
+++ b/articles/winter-2025/vr.html
@@ -217,6 +217,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -771,6 +771,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/privacy.html
+++ b/privacy.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>Waterloo Business Review</title>
-    <meta name="description" content="">
+    <meta name="description" content="Privacy Policy for Waterloo Business Review.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="manifest" href="site.webmanifest">
     <link rel="shortcut icon" type="image/x-icon" href="assets/img/favicon.ico">
@@ -24,7 +24,7 @@
 	<link rel="stylesheet" href="assets/css/nice-select.css">
 	<link rel="stylesheet" href="assets/css/style.css">
 </head>
-<body class="wbr-contact-page">
+<body class="wbr-privacy-page">
     <!-- ? Preloader Start -->
     <div id="preloader-active">
         <div class="preloader d-flex align-items-center justify-content-center">
@@ -35,7 +35,7 @@
                 </div>
             </div>
         </div>
-    </div> 
+    </div>
     <!-- Preloader Start-->
     <header>
         <!-- Header Start -->
@@ -51,7 +51,7 @@
                                     </div>
                                 </div>
                                 <div class="header-info-right d-flex align-items-center">
-                                   <ul id="top_navigation">                                          
+                                   <ul id="top_navigation">
                                        <li><a href="index.html">Home</a></li>
                                        <li><a href="about.html">About</a></li>
                                        <li><a href="team.html">Team</a></li>
@@ -67,21 +67,18 @@
                         <div class="row align-items-center">
                             <div class="col-12">
                                 <!-- logo 2 -->
-                                <!-- <div class="logo2">
-                                    <a href="index.html"><img src="assets/img/logo/wbr-logo-small.svg" alt=""></a>
-                                </div>  -->
                                 <!-- Main-menu -->
                                 <div class="main-menu text-center d-none d-lg-block">
-                                    <nav>                                                
-                                        <ul id="navigation">            
-                                            <li><a href="topics/alumni_insights.html">Alumni Insights</a></li>                                                                                                                         
+                                    <nav>
+                                        <ul id="navigation">
+                                            <li><a href="topics/alumni_insights.html">Alumni Insights</a></li>
                                             <li><a href="topics/business_strategy.html">Business Strategy</a></li>
                                             <li><a href="topics/entrepreneurship.html">Entrepeneurship</a></li>
                                             <li><a href="topics/technology.html">Technology</a></li>
                                         </ul>
                                     </nav>
                                 </div>
-                            </div> 
+                            </div>
                             <!-- Mobile Menu -->
                             <div class="col-12">
                                 <div class="mobile_menu d-block d-lg-none"></div>
@@ -102,7 +99,7 @@
                         <nav aria-label="breadcrumb">
                             <ol class="breadcrumb justify-content-center">
                                 <li class="breadcrumb-item"><a href="index.html">Home</a></li>
-                                <li class="breadcrumb-item"><a href="#">Contact</a></li> 
+                                <li class="breadcrumb-item"><a href="#">Privacy Policy</a></li>
                             </ol>
                         </nav>
                     </div>
@@ -110,94 +107,62 @@
             </div>
         </div>
         <!-- breadcrumb End -->
-<section class="wbr-page-title">
-    <div class="container">
-        <div class="row">
-            <div class="col-12">
-                <h1>Keep in Touch</h1>
-            </div>
-        </div>
-    </div>
-</section>
-<section class="wbr-contact-shell" id="contact">
-    <div class="container">
-        <div class="wbr-contact-hero">
-            <div class="wbr-contact-hero__logo">
-                <img src="assets/img/logo/wbr-logo.svg" alt="Waterloo Business Review">
-            </div>
-        </div>
-
-        <div class="wbr-contact-grid">
-            <section class="wbr-contact-panel wbr-contact-panel--map">
-                <div class="wbr-contact-panel__header">
-                    <span>Visit WBR</span>
-                    <h3>School of Accounting and Finance, University of Waterloo</h3>
-                </div>
-                <div class="wbr-contact-map">
-                    <iframe title="Waterloo Business Review location map" src="https://www.bing.com/maps/embed?h=520&w=1000&cp=43.47008840349448~-80.5479640740967&lvl=15&typ=d&sty=r&src=SHELL&FORM=MBEDV8" scrolling="no"></iframe>
-                    <div class="wbr-contact-map__overlay">
-                        <strong>200 University Ave W</strong>
-                        <span>Waterloo, Ontario</span>
+        <section class="wbr-page-title">
+            <div class="container">
+                <div class="row">
+                    <div class="col-12">
+                        <h1>Privacy Policy</h1>
                     </div>
                 </div>
-            </section>
-
-            <aside class="wbr-contact-sidebar">
-                <section class="wbr-contact-panel">
-                    <div class="wbr-contact-panel__header">
-                        <span>Editorial</span>
-                        <h3>Email the team directly.</h3>
-                    </div>
-                    <a class="wbr-contact-linkcard" href="mailto:waterloobusinessreview@gmail.com">
-                        <span class="wbr-contact-linkcard__icon"><i class="ti-email"></i></span>
-                        <div>
-                            <strong>waterloobusinessreview@gmail.com</strong>
-                            <p>Send pitches, questions, and partnership inquiries anytime.</p>
-                        </div>
-                    </a>
-                </section>
-
-                <section class="wbr-contact-panel">
-                    <div class="wbr-contact-panel__header">
-                        <span>Where To Start</span>
-                        <h3>Best routes depending on what you need.</h3>
-                    </div>
-                    <div class="wbr-contact-route">
-                        <strong>Writers and contributors</strong>
-                        <p>Use email to pitch article ideas, interviews, or issue concepts.</p>
-                    </div>
-                    <div class="wbr-contact-route">
-                        <strong>Readers and alumni</strong>
-                        <p>Reach out for archive questions, newsletter issues, or general inquiries.</p>
-                    </div>
-                    <div class="wbr-contact-route">
-                        <strong>Partners and sponsors</strong>
-                        <p>Use the same inbox for collaborations, event ideas, and brand partnerships.</p>
-                    </div>
-                </section>
-            </aside>
-        </div>
-
-        <section class="wbr-contact-notes">
-            <div class="wbr-contact-notes__intro">
-                <span>Why Contact</span>
-                <h3>A publication should feel reachable.</h3>
-            </div>
-            <div class="wbr-contact-notes__grid">
-                <article class="wbr-contact-note">
-                    <strong>Pitch a story</strong>
-                    <p>Share an angle, a market shift, or a company worth analyzing.</p>
-                </article>
-                <article class="wbr-contact-note">
-                    <strong>Connect with the team</strong>
-                    <p>Reach editors, operators, and contributors building the publication.</p>
-                </article>
             </div>
         </section>
-    </div>
-</section>
+        <!-- Post Details Stat -->
+        <div class="post-details pb-80">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-2"></div>
+                    <div class="col-12 col-lg-8">
+                        <div class="about-details-cap">
+                            <p class="mb-30"><b>Last updated:</b> June 24, 2026</p>
+                            <p class="mb-30">Waterloo Business Review ("WBR", "we", "us", or "our") is a student-run online publication operated by students at the University of Waterloo. This Privacy Policy explains what information we collect when you visit waterloobusinessreview.org (the "site"), how we use it, and the choices you have. By using the site, you agree to the practices described in this policy.</p>
 
-<!-- Contact Area End -->
+                            <h3>Information We Collect</h3>
+                            <p class="mb-30"><b>Information you give us.</b> When you contact us, subscribe to updates, or submit a question or article through the site, we may collect the information you choose to provide &mdash; such as your name and email address.</p>
+                            <p class="mb-30"><b>Information collected automatically.</b> Like most websites, we may automatically collect limited technical information when you visit, such as your browser type, device and operating system, referring pages, and general usage data. This information is collected through cookies and similar technologies.</p>
+
+                            <h3>How We Use Your Information</h3>
+                            <p class="mb-30">We use the information we collect to operate and maintain the site, respond to your inquiries, send updates you have requested, understand how readers use our content, and improve our publication. We do not sell your personal information.</p>
+
+                            <h3>Cookies and Analytics</h3>
+                            <p class="mb-30">We may use cookies and third-party analytics tools to understand site traffic and reader engagement in aggregate. Most web browsers let you refuse or delete cookies through their settings; doing so may affect how some parts of the site function.</p>
+
+                            <h3>Third-Party Services and Links</h3>
+                            <p class="mb-30">The site may use third-party services (for example, analytics, embedded maps, or social media links) and may contain links to external websites that we do not control. This policy does not apply to those third parties, and we encourage you to review their own privacy policies.</p>
+
+                            <h3>How We Share Information</h3>
+                            <p class="mb-30">We do not sell or rent your personal information. We may share information only with service providers who help us operate the site, when required by law, or to protect the rights, safety, and property of WBR and others.</p>
+
+                            <h3>Data Retention and Security</h3>
+                            <p class="mb-30">We retain personal information only for as long as needed for the purposes described in this policy. We take reasonable measures to protect the information we collect; however, no method of transmission or storage over the internet is completely secure, and we cannot guarantee absolute security.</p>
+
+                            <h3>Children's Privacy</h3>
+                            <p class="mb-30">The site is intended for a general audience and is not directed to children. We do not knowingly collect personal information from children. If you believe a child has provided us with personal information, please contact us so we can remove it.</p>
+
+                            <h3>Your Choices and Rights</h3>
+                            <p class="mb-30">You may unsubscribe from any updates at any time using the link provided in those messages, and you may request that we access, correct, or delete personal information we hold about you by contacting us. We will respond in accordance with applicable law.</p>
+
+                            <h3>Changes to This Policy</h3>
+                            <p class="mb-30">We may update this Privacy Policy from time to time. When we do, we will revise the "Last updated" date at the top of this page. We encourage you to review this policy periodically.</p>
+
+                            <h3>Contact Us</h3>
+                            <p class="mb-30">If you have any questions about this Privacy Policy or how we handle your information, you can reach us at <a href="mailto:waterloobusinessreview@gmail.com">waterloobusinessreview@gmail.com</a> or through our <a href="contact.html#contact">contact page</a>.</p>
+                        </div>
+                    </div>
+                    <div class="col-lg-2"></div>
+                </div>
+            </div>
+        </div>
+        <!-- Post Details End -->
     </main>
     <footer class="wbr-footer">
       <div class="container">
@@ -245,10 +210,6 @@
     <div id="back-top" >
         <a title="Go to Top" href="#"> <i class="fas fa-level-up-alt"></i></a>
     </div>
-    <!-- Scroll Up -->
-    <div id="back-top" >
-        <a title="Go to Top" href="#"> <i class="fas fa-level-up-alt"></i></a>
-    </div>
       <!-- JS here -->
 
       <script src="./assets/js/vendor/modernizr-3.5.0.min.js"></script>
@@ -272,7 +233,7 @@
       <!-- Nice-select, sticky -->
       <script src="./assets/js/jquery.nice-select.min.js"></script>
       <script src="./assets/js/jquery.sticky.js"></script>
-      
+
       <!-- counter , waypoint,Hover Direction -->
       <script src="./assets/js/jquery.counterup.min.js"></script>
       <script src="./assets/js/waypoints.min.js"></script>
@@ -285,10 +246,10 @@
       <script src="./assets/js/jquery.validate.min.js"></script>
       <script src="./assets/js/mail-script.js"></script>
       <script src="./assets/js/jquery.ajaxchimp.min.js"></script>
-      
-      <!-- Jquery Plugins, main Jquery -->	
+
+      <!-- Jquery Plugins, main Jquery -->
       <script src="./assets/js/plugins.js"></script>
       <script src="./assets/js/main.js"></script>
-     
+
     </body>
 </html>

--- a/publications.html
+++ b/publications.html
@@ -160,6 +160,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/fall-2019.html
+++ b/publications/fall-2019.html
@@ -384,6 +384,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/fall-2020.html
+++ b/publications/fall-2020.html
@@ -447,6 +447,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/fall-2021.html
+++ b/publications/fall-2021.html
@@ -449,6 +449,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/fall-2022.html
+++ b/publications/fall-2022.html
@@ -449,6 +449,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/fall-2023.html
+++ b/publications/fall-2023.html
@@ -449,6 +449,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/fall-2025.html
+++ b/publications/fall-2025.html
@@ -452,6 +452,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/spring-2020.html
+++ b/publications/spring-2020.html
@@ -447,6 +447,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/spring-2021.html
+++ b/publications/spring-2021.html
@@ -446,6 +446,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/spring-2024.html
+++ b/publications/spring-2024.html
@@ -452,6 +452,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/spring-2025.html
+++ b/publications/spring-2025.html
@@ -452,6 +452,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/winter-2020.html
+++ b/publications/winter-2020.html
@@ -446,6 +446,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/winter-2021.html
+++ b/publications/winter-2021.html
@@ -446,6 +446,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/winter-2024.html
+++ b/publications/winter-2024.html
@@ -449,6 +449,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/publications/winter-2025.html
+++ b/publications/winter-2025.html
@@ -452,6 +452,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/subscribe.html
+++ b/subscribe.html
@@ -173,6 +173,7 @@
                         <h4>Keep in Touch</h4>
                         <ul>
                             <li><a href="contact.html#contact">Contact</a></li>
+                            <li><a href="/privacy.html">Privacy Policy</a></li>
                         </ul>
                     </div>
                 </div>

--- a/team-2021.html
+++ b/team-2021.html
@@ -171,6 +171,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/team-2023.html
+++ b/team-2023.html
@@ -312,6 +312,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/team.html
+++ b/team.html
@@ -303,6 +303,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/team_2021.html
+++ b/team_2021.html
@@ -171,6 +171,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/topics/alumni_insights.html
+++ b/topics/alumni_insights.html
@@ -325,6 +325,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/topics/business_strategy.html
+++ b/topics/business_strategy.html
@@ -1484,6 +1484,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/topics/entrepreneurship.html
+++ b/topics/entrepreneurship.html
@@ -312,6 +312,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/topics/technology.html
+++ b/topics/technology.html
@@ -765,6 +765,7 @@
               <h4>Keep in Touch</h4>
               <ul>
                 <li><a href="../contact.html#contact">Contact</a></li>
+                <li><a href="/privacy.html">Privacy Policy</a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Adds a **Privacy Policy** page to the site and makes it discoverable from every page's footer.

- **New `privacy.html`** at the repo root → serves at `https://www.waterloobusinessreview.org/privacy.html`. Built on the **current live site template** (standard header, top nav, topic nav, breadcrumb, `wbr-page-title`, `about-details-cap` content layout, and the `wbr-footer`). No inline styles — uses the site's existing CSS classes.
- **Footer link**: adds `Privacy Policy` → `/privacy.html` to the "Keep in Touch" footer column on **all 97 footer pages** (root-relative, so it resolves from any subdirectory). Exactly one line added per page.

## Details
- Placeholders filled: **Last updated: June 24, 2026**; contact **waterloobusinessreview@gmail.com** (the address used on the live contact page); in-body contact link → `contact.html#contact`.
- Policy text is a **generated standard privacy policy** for a student-run publication — please review the legal wording.
- Branched from the current `origin/master`, so the deployed April/May site is unaffected until this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)